### PR TITLE
Updated the homebrew command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _libvips_ can take advantage of [liborc](http://code.entropywave.com/orc/) if pr
 
 ### Install libvips on Mac OS
 
-    brew install vips --without-fftw --without-libexif --without-libgsf \
+    brew install homebrew/science/vips --without-fftw --without-libexif --without-libgsf \
       --without-little-cms2 --without-orc --without-pango --without-pygobject3 \
       --without-gobject-introspection --without-python
 


### PR DESCRIPTION
The command did not work with just `vips`.

This is the output as documented.

```bash
$ brew install vips --without-fftw --without-libexif --without-libgsf   --without-little-cms2 --without-orc --without-pango --without-pygobject3   --without-gobject-introspection --without-python
Error: No available formula for vips
Searching formulae...
Searching taps...
homebrew/science/vips
```

Here's the output following the change:

```bash
$ brew install homebrew/science/vips --without-fftw --without-libexif --without-libgsf   --without-little-cms2 --without-orc --without-pango --without-pygobject3   --without-gobject-introspection --without-python
==> Tapping Homebrew/science
Cloning into '/usr/local/Library/Taps/homebrew/homebrew-science'...
remote: Counting objects: 509, done.
remote: Compressing objects: 100% (505/505), done.
remote: Total 509 (delta 4), reused 162 (delta 3), pack-reused 0
Receiving objects: 100% (509/509), 383.11 KiB | 0 bytes/s, done.
Resolving deltas: 100% (4/4), done.
Checking connectivity... done.
Tapped 502 formulae (529 files, 2.6M)
==> Installing vips from homebrew/homebrew-science
==> Installing vips dependency: glib
==> Downloading https://homebrew.bintray.com/bottles/glib-2.44.1.yosemite.bottle.tar.gz
######################################################################## 100.0%
==> Pouring glib-2.44.1.yosemite.bottle.tar.gz
🍺  /usr/local/Cellar/glib/2.44.1: 416 files, 18M
==> Installing vips
==> Downloading http://www.vips.ecs.soton.ac.uk/supported/8.0/vips-8.0.2.tar.gz
######################################################################## 100.0%
==> ./configure --prefix=/usr/local/Cellar/vips/8.0.2
==> make check
==> make install
🍺  /usr/local/Cellar/vips/8.0.2: 178 files, 11M, built in 102 seconds
```