### PR TITLE
Fixed enlarge turning off

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -149,6 +149,17 @@ func Resize(buf []byte, o Options) ([]byte, error) {
 	// prepare for factor
 	factor := 0.0
 
+	// Do not enlarge the output if the input width *or* height are already less than the required dimensions
+	if !o.Enlarge {
+		if inWidth < o.Width {
+			o.Width = inWidth
+		}
+
+		if inHeight < o.Height {
+			o.Height = inHeight
+		}
+	}
+
 	// image calculations
 	switch {
 	// Fixed width and height
@@ -185,17 +196,6 @@ func Resize(buf []byte, o Options) ([]byte, error) {
 
 	// residual
 	residual := float64(shrink) / factor
-
-	// Do not enlarge the output if the input width *or* height are already less than the required dimensions
-	if !o.Enlarge {
-		if inWidth < o.Width && inHeight < o.Height {
-			factor = 1
-			shrink = 1
-			residual = 0
-			o.Width = inWidth
-			o.Height = inHeight
-		}
-	}
 
 	debug("factor: %v, shrink: %v, residual: %v", factor, shrink, residual)
 


### PR DESCRIPTION
Hey @DAddYE,

I've just run into a bug in the code regarding enlarge option.
In a comment at line 189 you wrote `if the input width *or* height are already less` but used `&&` operator. (here https://github.com/DAddYE/vips/blob/master/vips.go#L189)

This pull request just checks and changes width and height of returning image to the same as origin if they are bigger.

Also I've lifted up the condition before calculating factor, shrink and residual.
It is a small but useful fix :)